### PR TITLE
Add docker image scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+/models
+/data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM ursinbrunner/valuenet-inference-hack-zurich:1.0
+
+ARG VALUENET_PATH
+
+COPY data/hack_zurich /workspace/data/hack_zurich
+COPY models /workspace/models

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ MODELS_FOLDER=models
 
 .PHONY:build-image
 build-image:
-	cp -r $(VALUENET_PATH)/$(DATA_FOLDER) $(DATA_FOLDER) \
+	mkdir -p data \
+	&& cp -r $(VALUENET_PATH)/$(DATA_FOLDER) $(DATA_FOLDER) \
 	&& cp -r $(VALUENET_PATH)/$(MODELS_FOLDER) $(MODELS_FOLDER) \
 	&& docker build \
 		--no-cache \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+BUILD_NAME=hackzurich2021
+VERSION=latest
+VALUENET_PATH=../valuenet
+DATA_FOLDER=data/hack_zurich
+MODELS_FOLDER=models
+
+.PHONY:build-image
+build-image:
+	cp -r $(VALUENET_PATH)/$(DATA_FOLDER) $(DATA_FOLDER) \
+	&& cp -r $(VALUENET_PATH)/$(MODELS_FOLDER) $(MODELS_FOLDER) \
+	&& docker build \
+		--no-cache \
+		--tag $(BUILD_NAME):$(VERSION) \
+		--build-arg VALUENET_PATH=$(VALUENET_PATH) \
+		.

--- a/README.md
+++ b/README.md
@@ -30,5 +30,12 @@ There are then 3 notebooks:
 
 ## Publish the docker image
 
-1. Run `build-image <path-to-experiment-folder>` (eg. `../valuenet/experiments/train-02__20210921_101600`) to build the image with your data
-2. Run `./publish_image.sh latest <your-target-tag>` (eg. `1.0.0` or  `20210923_212235`)
+1. Run `./build-image <path-to-experiment-folder>` (eg. `../valuenet/experiments/train-02__20210921_101600`) to build the image with your data
+2. Run `./publish_image.sh latest <your-target-tag>` (eg. `1.0.0` or  `20210921_101600`)
+
+Here is an example to build an image with model from experience `train-02__20210921_101600`:
+
+```console
+$ ./build-image ../valuenet/experiments/train-02__20210921_101600
+$ ./publish_image.sh latest 20210921_101600
+```

--- a/README.md
+++ b/README.md
@@ -27,3 +27,8 @@ There are then 3 notebooks:
 - train-01.ipynb:
 
   This notebooks is responsible for the training part. Make sure to run [preprocess_custom_data-01.ipynb](https://github.com/hack-with-admin-ch/aws-sagemaker-notebook-valuenet/blob/main/preprocess_custom_data-01.ipynb) first if you use custom data. It then guides through the options and steps to train a model from scratch or pre-trained and to train on spider dataset or with your custom data.
+
+## Publish the docker image
+
+1. Run `make build-image` to build the image with your data
+2. Run `./publish_image.sh latest <your-target-tag>` (eg. `1.0.0` or  `20210923_212235`)

--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ There are then 3 notebooks:
 
 ## Publish the docker image
 
-1. Run `make build-image` to build the image with your data
+1. Run `build-image <path-to-experiment-folder>` (eg. `../valuenet/experiments/train-02__20210921_101600`) to build the image with your data
 2. Run `./publish_image.sh latest <your-target-tag>` (eg. `1.0.0` or  `20210923_212235`)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # aws-sagemaker-notebook-valuenet
 
-
 This repository containes configuration files and notebooks to run [Valuenet](https://github.com/brunnurs/valuenet) codebase in AWS Sagemaker.
 
-### Configuration
+## Configuration
 
 In the folder configuration/scripts, you can find the script to prepare the instance.
 
@@ -13,16 +12,18 @@ In the folder configuration/scripts, you can find the script to prepare the inst
 
 More information is available [here](https://docs.aws.amazon.com/sagemaker/latest/dg/notebook-lifecycle-config.html).
 
-### Notebooks
-There are then 3 notebooks:
-- setup.ipynb: 
+## Notebooks
 
-    This notebook prepares the environemnt to run the codebase, installs all required pip libraries and validate the the gpu is available
-    
+There are then 3 notebooks:
+
+- setup.ipynb:
+
+  This notebook prepares the environemnt to run the codebase, installs all required pip libraries and validate the the gpu is available
+
 - preprocess_custom_data-01.ipynb:
 
-    This notebook prepares the custom data. If you generate some custom data (with the help of [question query generation](https://github.com/statistikZH/statbot/blob/main/hackathon_hackzurich/generate_sql_statments_and_questions.ipynb) for instance), this notebooks takes you through the preprocessing steps to be ready to train.
-    
+  This notebook prepares the custom data. If you generate some custom data (with the help of [question query generation](https://github.com/statistikZH/statbot/blob/main/hackathon_hackzurich/generate_sql_statments_and_questions.ipynb) for instance), this notebooks takes you through the preprocessing steps to be ready to train.
+
 - train-01.ipynb:
 
-    This notebooks is responsible for the training part. Make sure to run [preprocess_custom_data-01.ipynb](https://github.com/hack-with-admin-ch/aws-sagemaker-notebook-valuenet/blob/main/preprocess_custom_data-01.ipynb) first if you use custom data. It then guides through the options and steps to train a model from scratch or pre-trained and to train on spider dataset or with your custom data.
+  This notebooks is responsible for the training part. Make sure to run [preprocess_custom_data-01.ipynb](https://github.com/hack-with-admin-ch/aws-sagemaker-notebook-valuenet/blob/main/preprocess_custom_data-01.ipynb) first if you use custom data. It then guides through the options and steps to train a model from scratch or pre-trained and to train on spider dataset or with your custom data.

--- a/build_image.sh
+++ b/build_image.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+if [ $# -ne 1 ]
+  then
+    echo 'Synopsis: build_image.sh <experiments_folder>'
+    exit 1
+fi
+
+BUILD_NAME=hackzurich2021
+VERSION=latest
+VALUENET_PATH=../valuenet
+DATA_FOLDER=data/hack_zurich
+MODELS_FOLDER=models
+
+mkdir -p data
+cp -r "$VALUENET_PATH/$DATA_FOLDER" $DATA_FOLDER
+cp -r $1 $MODELS_FOLDER
+docker build \
+    --no-cache \
+    --tag "$BUILD_NAME:$VERSION" \
+    --build-arg VALUENET_PATH="$VALUENET_PATH" \
+    .

--- a/publish_image.sh
+++ b/publish_image.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+BUILD_NAME=hackzurich2021
+
+if [ $# -ne 2 ]
+  then
+    echo 'Synopsis: publish_image.sh <source-tag> <destination-tag>'
+    exit 1
+fi
+
+aws ecr get-login-password --region eu-central-1 | docker login --username AWS --password-stdin 907390762462.dkr.ecr.eu-central-1.amazonaws.com
+
+docker tag "$BUILD_NAME:$1" "907390762462.dkr.ecr.eu-central-1.amazonaws.com/$BUILD_NAME:$2"
+
+docker push "907390762462.dkr.ecr.eu-central-1.amazonaws.com/$BUILD_NAME:$2"


### PR DESCRIPTION
## What has been done

- A `Dockerfile` to build a new image with a new model has been added
- A `Makefile` and a `publish_image.sh` script have been added to make image publish easier (usage is documented in the README)
- The README has been formatted and updated

We are just missing the calls to these scripts from the notebooks to images publish automatically based on the experiment's timestamp.
